### PR TITLE
Fixed service not booting up correctly

### DIFF
--- a/scripts/etc/init.d/luafcgid.debian
+++ b/scripts/etc/init.d/luafcgid.debian
@@ -54,13 +54,13 @@ do_start()
 	#   2 if daemon could not be started
 	start-stop-daemon --start --chuid $USER --quiet --pidfile $PIDFILE --exec $DAEMON --test > /dev/null \
 		|| return 1
-	start-stop-daemon --start --chuid $USER --quiet --pidfile $PIDFILE --exec $DAEMON -- \
+	start-stop-daemon --start --chuid $USER --quiet -b --pidfile $PIDFILE --exec $DAEMON -- \
 		$DAEMON_ARGS \
 		|| return 2
 	# Add code here, if necessary, that waits for the process to be ready
 	# to handle requests from services started subsequently which depend
 	# on this one.  As a last resort, sleep for some time.
-	echo `pgrep -P 1 -U $USER -n -f $DAEMON` > $PIDFILE
+	pgrep -P 1 -U $USER -n -f $DAEMON > $PIDFILE
 }
 
 #


### PR DESCRIPTION
The service relied on the luafcgid applicative detaching automatically.
Added "background" flag in order to detach from the luafcgid application manually, allowing the process id to be stored correctly, and allowing for a correct service stop.

Fixes multiple luafcgid processes running in "top" after you reload the service multiple times.